### PR TITLE
fixed query find only the product pages that are under the current page.

### DIFF
--- a/core/src/main/java/com/adobe/guides/aem/components/core/models/CategoryListImpl.java
+++ b/core/src/main/java/com/adobe/guides/aem/components/core/models/CategoryListImpl.java
@@ -84,7 +84,7 @@ public class CategoryListImpl extends AbstractComponentImpl implements CategoryL
 
         try {
             templateName = getTemplateName(cqTemplate);
-            categoryList = findPagesByTemplate(request.getResourceResolver(), FilenameUtils.concat(SLASH, FilenameUtils.concat(CONF_PATH_TOKEN,FilenameUtils.concat(templateName , TEMPLATE_PATH_TOKEN))), FilenameUtils.concat(SLASH, FilenameUtils.concat(CONTENT_PATH_TOKEN, templateName)));
+            categoryList = findPagesByTemplate(request.getResourceResolver(), FilenameUtils.concat(SLASH, FilenameUtils.concat(CONF_PATH_TOKEN,FilenameUtils.concat(templateName , TEMPLATE_PATH_TOKEN))), currentPage.getPath());
         } catch (RepositoryException e) {
             logger.error("Unable to retrieve category list for current template.", e);
         } catch (GuidesRuntimeException e) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Limiting the query scope of categorylist component to its container page's scope.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

The categorylist component used to list other language copies' product pages as well, breaking the isolation completely and leaving the users confused. 


## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
