### PR TITLE
reverted the util.tracker version to 1.5.1

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -282,7 +282,7 @@ Embed-Dependency: jsoup;scope=compile|runtime;inline=true
                 <dependency>
                     <groupId>org.osgi</groupId>
                     <artifactId>org.osgi.util.tracker</artifactId>
-                    <version>1.5.0</version>
+                    <version>1.5.1</version>
                     <scope>provided</scope>
                 </dependency>
                 <dependency>


### PR DESCRIPTION


## Description
Reverting the "org.osgi.util.tracker" version to default version 1.5.1

